### PR TITLE
add base64 encoding capabilities

### DIFF
--- a/epp.go
+++ b/epp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -30,6 +31,8 @@ func main() {
 		fmt.Fprintln(os.Stderr, "error: an input file is required")
 		os.Exit(1)
 	}
+
+	pongo2.RegisterFilter("b64enc", filterBase64Encode)
 
 	fileContents, err := readInput(flag.Arg(0))
 	if err != nil {
@@ -84,4 +87,8 @@ func environToContext() pongo2.Context {
 	}
 
 	return ctx
+}
+
+func filterBase64Encode(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	return pongo2.AsValue(base64.StdEncoding.EncodeToString([]byte(in.String()))), nil
 }

--- a/epp_test.go
+++ b/epp_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/flosch/pongo2"
 )
 
 func init() {
@@ -47,5 +49,19 @@ I should!
 
 	if string(res) != expected {
 		t.Errorf("bad expansion: expected '%s', got '%s'", expected, res)
+	}
+}
+
+func TestFilterBase64Encode(t *testing.T) {
+	actualResult, err := filterBase64Encode(pongo2.AsValue("Hello"), pongo2.AsValue(""))
+
+	if err != nil {
+		t.Errorf("unexpected error '%s'", err)
+	}
+
+	expectedResult := "SGVsbG8="
+
+	if actualResult.String() != expectedResult {
+		t.Errorf("Expected %s but got %s", expectedResult, actualResult)
 	}
 }


### PR DESCRIPTION
Makes it easy to do:

```
{{ "my value" | b64enc }}
```